### PR TITLE
chore: link to immunifi bug bounty

### DIFF
--- a/docs/bug-bounty.md
+++ b/docs/bug-bounty.md
@@ -1,8 +1,0 @@
-# Bug bounty
-
-### Bug bounty and disclosure of sercurity vulnerabilities
-Axelar is currently concluding collaborations with external partners on a process for disclosure of security vulnerabilities and a bug bounty program. In the meantime, here's what you need to know:
-
-* A _security vulnerability_ is a software bug that might compromise safety or liveness of the Axelar network. Examples include loss of funds or an unwanted network halt. Security vulnerabilities can have a range of severity levels.
-* If you find a security vulnerability then please send an email to `security@axelar.network` describing the vulnerability. Include all necessary information such as a description of the vulnerability, how to reproduce it, and the potential consequences.
-* The Axelar team will review submissions and award cash bounties to those who disclose valid vulnerabilities in such a way that we are able to patch the vulnerability before it is exploited.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,7 +67,7 @@ const config = {
             items: [
               {
                 label: 'Bug bounty',
-                to: '/bug-bounty',
+                href: 'https://immunefi.com/bounty/axelarnetwork/',
               },
               {
                 label: 'Terms of use',

--- a/sidebars.js
+++ b/sidebars.js
@@ -134,7 +134,11 @@ const sidebars = {
       ],
     },
     'ecosystem',
-    'bug-bounty',
+    {
+      type: 'link',
+      label: 'Bug bounty',
+      href: 'https://immunefi.com/bounty/axelarnetwork/',
+    },
   ],
 
   controllerSidebar: [

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,16 @@
 {
-    "redirects": [
-        {
-            "source": "/resources/mainnet-releases",
-            "destination": "/releases/mainnet"
-        },
-        {
-            "source": "/resources/testnet-releases",
-            "destination": "/releases/testnet"
-        }
-    ]
+  "redirects": [
+    {
+      "source": "/resources/mainnet-releases",
+      "destination": "/releases/mainnet"
+    },
+    {
+      "source": "/resources/testnet-releases",
+      "destination": "/releases/testnet"
+    },
+    {
+      "source": "/bug-bounty",
+      "destination": "https://immunefi.com/bounty/axelarnetwork/"
+    }
+  ]
 }


### PR DESCRIPTION
This PR removes mention of `security@axelar.network`.  Do we still want to promote this email list?