### PR TITLE
chore: restore a basic bug-bounty page

### DIFF
--- a/docs/bug-bounty.md
+++ b/docs/bug-bounty.md
@@ -1,0 +1,8 @@
+# Bug bounty
+
+There are two ways to disclose security vulnerabilities to the Axelar team:
+
+1. Submit a report to our <a href="https://immunefi.com/bounty/axelarnetwork/" target="_blank" rel="noopener noreferrer">bug bounty program</a>.
+2. Send email to `security@axelar.network` describing the vulnerability.
+
+Even if your security vulnerability is not eligible for a bounty from the bug bounty program (option 1) the Axelar team might decide to award a bounty for a security vulnerability submitted by email to `security@axelar.network` (option 2).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,7 +67,7 @@ const config = {
             items: [
               {
                 label: 'Bug bounty',
-                href: 'https://immunefi.com/bounty/axelarnetwork/',
+                href: 'bug-bounty',
               },
               {
                 label: 'Terms of use',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,7 +67,7 @@ const config = {
             items: [
               {
                 label: 'Bug bounty',
-                href: 'bug-bounty',
+                href: '/bug-bounty',
               },
               {
                 label: 'Terms of use',

--- a/sidebars.js
+++ b/sidebars.js
@@ -134,11 +134,7 @@ const sidebars = {
       ],
     },
     'ecosystem',
-    {
-      type: 'link',
-      label: 'Bug bounty',
-      href: 'https://immunefi.com/bounty/axelarnetwork/',
-    },
+    'bug-bounty',
   ],
 
   controllerSidebar: [

--- a/vercel.json
+++ b/vercel.json
@@ -7,10 +7,6 @@
     {
       "source": "/resources/testnet-releases",
       "destination": "/releases/testnet"
-    },
-    {
-      "source": "/bug-bounty",
-      "destination": "https://immunefi.com/bounty/axelarnetwork/"
     }
   ]
 }


### PR DESCRIPTION
Following #68 , we decided to restore mention of the security email address as another channel for vulnerability disclosure.