### PR TITLE
doc: hacknet instructions

### DIFF
--- a/docs/roles/dev/hackathon.md
+++ b/docs/roles/dev/hackathon.md
@@ -9,6 +9,14 @@ This document will be updated frequently.
 - Set up the [Axelar local test environment](local.md)
 - Use the [AxelarJS SDK](sdk.md)
 
+## Hacknet
+
+Axelar has set up a special new "hacknet" network (different form testnet/mainnet).
+
+Hacknet RPC endpoint: https://hackathon-nodes.devnet.axelar.dev/
+
+Need test AXL or UST tokens? Reach out to an Axelar team member in person at the event or on discord (link below).
+
 ## Tech support
 
 Join the [Axelar discord](https://discord.gg/aRZ3Ra6f7D) and visit the [developers channel](https://discord.com/channels/770814806105128977/955655587260170272).
@@ -24,3 +32,23 @@ Join the [Axelar discord](https://discord.gg/aRZ3Ra6f7D) and visit the [develope
 - Cross-chain asset management
   - Deposit asset A from chain C, earn yield on chain D.
 - Universal payments, NFT / game asset portability
+
+## Spin up an Axelar hacknet node
+
+Join hacknet:
+
+```bash
+git clone git@github.com:axelarnetwork/axelarate-community.git
+cd axelarate-community
+
+# start your node
+KEYRING_PASSWORD=my-secret-password ./scripts/node.sh -n hacknet
+
+# view logs
+tail -f ~/.axelar_hacknet/logs/axelard.log
+
+# stop your node
+kill -9 $(pgrep -f "axelard start")
+```
+
+Need more info? See detailed instructions for testnet/mainnet: [Quick sync](../node/join.md)

--- a/docs/roles/dev/hackathon.md
+++ b/docs/roles/dev/hackathon.md
@@ -2,8 +2,6 @@
 
 :::caution Under construction
 
-This document will be updated frequently.
-
 :::
 
 - Set up the [Axelar local test environment](local.md)
@@ -13,9 +11,9 @@ This document will be updated frequently.
 
 Axelar has set up a special new "hacknet" network (different form testnet/mainnet).
 
-Hacknet RPC endpoint: https://hackathon-nodes.devnet.axelar.dev/
+Axelar hacknet RPC endpoint: https://hackathon-nodes.devnet.axelar.dev/
 
-Need test AXL or UST tokens? Reach out to an Axelar team member in person at the event or on discord (link below).
+Need Axelar-hacknet-wrapped AXL or UST test tokens? Reach out to an Axelar team member in person at the event or on discord (link below).
 
 ## Tech support
 
@@ -52,3 +50,11 @@ kill -9 $(pgrep -f "axelard start")
 ```
 
 Need more info? See detailed instructions for testnet/mainnet: [Quick sync](../node/join.md)
+
+:::caution Sync issue for ARM build
+
+Trouble syncing your hacknet node? Axelar team has identified an issue with Apple M1 chips running axelar-core hacknet arm64 build. Team is investigating.
+
+Workaround: switch to an AMD build.
+
+:::


### PR DESCRIPTION
Currently hackathon doc has instructions only for local test environment.  Need instructions for deploying to hacknet, too.