### PR TITLE
doc: keyring for CLI commands

### DIFF
--- a/docs/roles/node/keyring.md
+++ b/docs/roles/node/keyring.md
@@ -1,0 +1,62 @@
+# Keyring backend
+
+Many Axeler CLI commands require an Axelar account controlled by a secret key. Your secret key must be stored securely so as to minimize the risk of exposure to an attacker.
+
+Like every Cosmos-based network, Axelar nodes store secret keys in a _keyring_. The keyring can be configured with one of several _backend_ implementations. Learn more about keyring backend configuration from the [Cosmos keyring documentation](https://docs.cosmos.network/v0.44/run-node/keyring.html).
+
+Axelar nodes use the `file` keyring backend by default. This means that your secret keys are stored in a password-encrypted file on disk. Under the `file` backend, you must provide your keyring password each time you execute certain Axelar CLI commands.
+
+:::caution Protect your keyring password
+
+There are several methods to provide your password for Axelar CLI commands. Each method comes with its own security and convenience properties. Whichever method you choose, be sure to follow best practices to keep your keyring password safe.
+
+:::
+
+## Manual password entry
+
+A simple and highly-secure method for password entry is to type your password whenever an Axelar CLI command prompts for it. For example, you can print the address of your account named `my_account` as follows:
+
+```bash
+axelard keys show my_account -a
+Enter keyring passphrase: {TYPE_YOUR_PASSWORD_HERE}
+axelar1r25hycaye0uz3k554mdu4a7dvc82uelj7y6ddn
+```
+
+## Automatic password entry
+
+It can be inconvenient to type your password for each Axlear CLI command, especially if you wish to automate CLI commands.
+
+Suppose your keyring password is stored in a shell environment variable called `KEYRING_PASSWORD`. You could prefix your CLI commands with `echo $KEYRING_PASSWORD | `. For example:
+
+```bash
+echo $KEYRING_PASSWORD | axelard keys show my_account -a
+axelar1r25hycaye0uz3k554mdu4a7dvc82uelj7y6ddn
+```
+
+:::danger
+
+If an attacker were to gain access to your system then the attacker could read your keyring password from your shell environment and then use it to expose your secret keys.
+
+:::
+
+## Axelar documentation elides password entry
+
+For clarity, Axelar CLI documentation elides password entry from CLI commands. You must amend CLI commands according to whichever method of password entry you choose.
+
+Example: to print the address of your account named `my_account` we write only
+
+```bash
+axelard keys show my_account -a
+axelar1r25hycaye0uz3k554mdu4a7dvc82uelj7y6ddn
+```
+
+## Security risks of automatic password entry
+
+Automatic password entry is convenient, but any such method must store the plaintext password somewhere. Plaintext password storage is a security risk. It is your responsibility to add
+
+This article is not a comprehensive guide to password security. Instead we offer only the following tips:
+
+- Keep your password out of your shell history. For example, never prefix a CLI command with your plaintext password: `echo my-secret-password | `.
+- Consider using a different keyring backend configuration so as to reduce the number of times you need to type your password.
+- TODO risks of storing password in a file in plaintext? [link](https://stackoverflow.com/questions/12461484/is-it-secure-to-store-passwords-as-environment-variables-rather-than-as-plain-t)
+- TODO fancy ramfs solutions? [link](https://medium.com/chainode-tech/improving-validator-security-and-using-hsm-module-for-2fa-aa8b451bd84f)

--- a/docs/roles/node/keyring.md
+++ b/docs/roles/node/keyring.md
@@ -49,14 +49,3 @@ Example: to print the address of your account named `my_account` we write only
 axelard keys show my_account -a
 axelar1r25hycaye0uz3k554mdu4a7dvc82uelj7y6ddn
 ```
-
-## Security risks of automatic password entry
-
-Automatic password entry is convenient, but any such method must store the plaintext password somewhere. Plaintext password storage is a security risk. It is your responsibility to add
-
-This article is not a comprehensive guide to password security. Instead we offer only the following tips:
-
-- Keep your password out of your shell history. For example, never prefix a CLI command with your plaintext password: `echo my-secret-password | `.
-- Consider using a different keyring backend configuration so as to reduce the number of times you need to type your password.
-- TODO risks of storing password in a file in plaintext? [link](https://stackoverflow.com/questions/12461484/is-it-secure-to-store-passwords-as-environment-variables-rather-than-as-plain-t)
-- TODO fancy ramfs solutions? [link](https://medium.com/chainode-tech/improving-validator-security-and-using-hsm-module-for-2fa-aa8b451bd84f)

--- a/docs/roles/node/keyring.md
+++ b/docs/roles/node/keyring.md
@@ -19,7 +19,6 @@ A simple and highly-secure method for password entry is to type your password wh
 ```bash
 axelard keys show my_account -a
 Enter keyring passphrase: {TYPE_YOUR_PASSWORD_HERE}
-axelar1r25hycaye0uz3k554mdu4a7dvc82uelj7y6ddn
 ```
 
 ## Automatic password entry
@@ -30,7 +29,6 @@ Suppose your keyring password is stored in a shell environment variable called `
 
 ```bash
 echo $KEYRING_PASSWORD | axelard keys show my_account -a
-axelar1r25hycaye0uz3k554mdu4a7dvc82uelj7y6ddn
 ```
 
 :::danger
@@ -47,5 +45,4 @@ Example: to print the address of your account named `my_account` we write only
 
 ```bash
 axelard keys show my_account -a
-axelar1r25hycaye0uz3k554mdu4a7dvc82uelj7y6ddn
 ```

--- a/sidebars.js
+++ b/sidebars.js
@@ -71,6 +71,7 @@ const sidebars = {
             'roles/node/join',
             'roles/node/join-genesis',
             'roles/node/basic',
+            'roles/node/keyring',
           ],
         },
         {


### PR DESCRIPTION
Goal: Explain to the reader that we will not write `echo $KEYRING_PASSWORD | ` everywhere.  Explain barely enough about keyring backend to communicate that idea, and refer to Cosmos docs for the rest.