### PR TITLE
docs: rework dev landing page

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -1,24 +1,61 @@
 # Developer
 
-:::caution Under construction
+## Develop your cross-chain dapp in 2 simple steps
 
-:::
+1. **_Build._** Develop and test in the Axelar local development environment
+2. **_Deploy._** Deploy to a live network: testnet or mainnet
 
-## Develop your cross-chain dapp in 3 simple steps
+## Example: Hello-world
 
-1. Build cross-chain contracts in the [Axelar local development environment](https://github.com/axelarnetwork/axelar-local-dev).
-2. Deploy your dapp to testnet or hacknet.
-3. Deploy your dapp to mainnet and go global.
+`axelar-local-dev-sample` is a complete, working example illustrating the build-deploy process. _[TODO Under construction!]_
 
-# Local development environment
+1. Run the dapp in the local development environment.
+2. Run the same dapp in the live testnet, interacting with contracts already deployed on Ethereum and Avalanche testnets.
+
+View the github README for instructions and code:
+
+Button: [axelar-local-dev-sample](https://github.com/axelarnetwork/axelar-local-dev-sample)
+
+## Build
 
 The Axelar local development environment emulates multiple EVM chains and the Axelar overlay network that connects them.
 
-See [axelar-local-dev git repo README](https://github.com/axelarnetwork/axelar-local-dev).
+1. Create new emulated EVM chains pre-loaded with ERC-20 tokens and gateway contracts.
+2. Write your own `IAxelarExecutable` contracts and deploy to your emulated EVM chains.
+3. Call your `IAxelarExecutable` contracts from any chain via that chain's gateway contract. Use `relay()` to simulate the Axelar overlay network.
 
-## Example dapps
+Learn more at the `axelar-local-dev` github README:
+
+Button: [Axelar local development environment](https://github.com/axelarnetwork/axelar-local-dev)
+
+## Deploy
+
+When you're ready to go live:
+
+1. Deploy your `IAxelarExecutable` contracts to any EVM chain supported by Axelar.
+2. Remove calls to `relay()`---the Axelar network will handle everything for you!
+
+See `axelar-local-dev-sample` for a working example:
+
+Button: [axelar-local-dev-sample](https://github.com/axelarnetwork/axelar-local-dev-sample)
+
+## More examples
 
 - [Simple](https://github.com/axelarnetwork/axelar-local-dev/tree/main/examples/simple). Set up two EVM chains, transfer tokens from one chain to the other, send a "Hello world!" message to a contract on both chains.
 - [Metamask](https://github.com/axelarnetwork/axelar-local-dev/tree/main/examples/metamask). Set up two EVM chains and a simple web page to connect Metamask and transfer tokens from one chain to the other.
 - [Remote](https://github.com/axelarnetwork/axelar-local-dev/tree/main/examples/remote). Set up a test environment and connect to it remotely.
 - [Token linker](https://github.com/axelarnetwork/axelar-local-dev/tree/main/examples/tokenLinker). Use cross-chain contract calls to transfer ERC-20 tokens across EVM chains.
+- More to come
+
+## AxelarJS SDK
+
+The AxelarJS SDK is a `npm` dependency that empowers developers to leverage microservices or IBC relayers provided by Axelar.
+
+Not all dapps need the SDK. _[TODO review the following.]_ Your dapp might benefit from the SDK in the following use cases:
+
+1. **_Microservices._** Example: Get a deposit address for cross-chain token transfer dapps like [Satellite](resources/satellite.md).
+2. **_Relayers._** Example: Connect EVM chains to Cosmos chains such as Terra.
+
+Learn more at the `axelarjs-sdk` github README:
+
+Button: [axelarjs-sdk](https://github.com/axelarnetwork/axelarjs-sdk)

--- a/sidebars.js
+++ b/sidebars.js
@@ -24,17 +24,6 @@ const sidebars = {
       label: 'Developer',
       link: {type: 'doc', id: 'dev'},
       items: [
-        {
-          type: 'category',
-          label: 'AxelarJS SDK',
-          link: {type: 'doc', id: 'dev/sdk'},
-          items: [
-            'dev/sdk/axelarjs-stable',
-            'dev/sdk/axelarjs-alpha',
-            'dev/sdk/deposit-address-demo-stable',
-            'dev/sdk/deposit-address-demo-alpha',
-          ],
-        },
         'dev/gmp',
         {
           type: 'category',
@@ -113,8 +102,6 @@ const sidebars = {
     {
       type: 'category',
       label: 'Resources',
-      collapsible: true,
-      collapsed: false,
       link: {type: 'doc', id: 'resources'},
       items: [
         {


### PR DESCRIPTION
- 2-step process: build (local), deploy (live)
- working hello-world example in axelar-local-dev-sample repo.  (It's not actually working yet.)
- introduce axelarjs-sdk at the end, explain when it should be used.  (Need someone else to verify this explanation.)
- remove sdk from sidebar, instead rely on github readme
- need fancy buttons to emphasize certain links, currently tagged with "button:"